### PR TITLE
Running before filtering

### DIFF
--- a/src/main/python/pybuilder_smart_copy_resources/__init__.py
+++ b/src/main/python/pybuilder_smart_copy_resources/__init__.py
@@ -18,9 +18,8 @@ def init_smart_copy_plugin(project, logger):
     project.set_property_if_unset("smart_copy_resources", {})
     project.set_property_if_unset("smart_copy_resources_basedir", project.basedir)
 
-@task("smart_copy_resources", "Copy additional resources to required destinations")
-def smart_copy_resources(project, logger):
-
+@task
+def package(project, logger):
     logger.info(u"Copying additional resource files")
 
     # Get the properties


### PR DESCRIPTION
If we run smart-copy-resources as separated step copied file will not be affected by filtering (filtering call as after-package). But moving all resources is a part of packaging. So we can call smart-copy-resources as original copying resources (which is part of packaging). The same behaviour for basic and additional copying looks like more expected.